### PR TITLE
[Task] BE: Sort stories in sprints #TDB-47

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -5,7 +5,7 @@ class Story < ApplicationRecord
     {:open => 0, :progressing => 1, :closed => 2, :canceled => 3}
   end
 
-  acts_as_list
+  acts_as_list scope: [:sprint_id]
 
   after_save :set_identifier
   before_validation :set_status

--- a/db/migrate/20171126215843_story_position_depends_on_sprint.rb
+++ b/db/migrate/20171126215843_story_position_depends_on_sprint.rb
@@ -1,0 +1,10 @@
+class StoryPositionDependsOnSprint < ActiveRecord::Migration[5.1]
+  def change
+    Story.each do |story|
+      story.position = 0
+    end
+    Story.order(:created_at).reverse.each do |story|
+      story.move_to_bottom
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121214147) do
+ActiveRecord::Schema.define(version: 20171126215843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
- [X] stories NOT in sprints are sorted within the entire backlog
(sorting by null value)
- [X] stories IN sprints are sorted within their respective sprints
(sorting by sprint id)
- [X] stories in PAST sprints cannot be re-sorted (only next sprint)
(stories which live in past sprints, are not editable anymore)
- [X] stories NEWLY ADDED to sprint are sorted at the bottom of the sprint list
(stories are moved to the bottom, depending on sprint id column)