### PR TITLE
[Task] add role column to users #TDB-168

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ApplicationRecord
 
   def set_role
     if self.role.blank?
-      self.status = User.roles[:student]
+      self.role = User.roles[:student]
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,19 @@ class User < ApplicationRecord
   has_many :memberships
   has_many :projects, through: :memberships
 
+  def self.roles
+    { :student => 0, :instructor => 1 }
+  end
+
+  before_validation :set_role
+
   validates :email, presence: true, uniqueness: true
+
+  private
+
+  def set_role
+    if self.role.blank?
+      self.status = User.roles[:student]
+    end
+  end
 end

--- a/db/migrate/20180121232727_add_role_column_on_users.rb
+++ b/db/migrate/20180121232727_add_role_column_on_users.rb
@@ -1,0 +1,8 @@
+class AddRoleColumnOnUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :role, :integer, default: User.roles[:student]
+    User.all.each.with_index(1) do |user|
+      user.update_column :role, User.roles[:student]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180120182857) do
+ActiveRecord::Schema.define(version: 20180121232727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 20180120182857) do
 
   create_table "users", force: :cascade do |t|
     t.string "email"
+    t.integer "role", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -14,4 +14,13 @@ RSpec.describe User, type: :model do
     subject.save!
     expect(subject.projects.size).to eq(10)
   end
+
+  it "should get a default status on save" do
+    subject = create(:user)
+    expect(subject).to be_valid
+    subject.role = nil
+    subject.save
+    expect(subject.role).to be(User.roles[:student])
+  end
+
 end


### PR DESCRIPTION
This field will set the inital role for users.
When the LDAP is implemented, this column will be set via LDAP authentication.
This role-column decides, who is able to create courses.

In the future, students can be instructors of a specific course only, by invitation of a instructor with this initial role.